### PR TITLE
Disk should return the size of the disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yields (without logging output):
       	  ],
       	  "cpu": "12",
       	  "memory": "98304",
-      	  "disk": "7",
+      	  "disk": "500",
       	  "arch": "x86_64"
     	},
     	{
@@ -41,7 +41,7 @@ yields (without logging output):
       	  ],
       	  "cpu": "16",
       	  "memory": "131072",
-      	  "disk": "0",
+      	  "disk": "500",
       	  "arch": "x86_64"
     	},
         {
@@ -59,7 +59,7 @@ yields (without logging output):
       	  ],
       	  "cpu": "20",
       	  "memory": "98304",
-      	  "disk": "1",
+      	  "disk": "1200",
       	  "arch": "x86_64"
         }
       ]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-This is an idrac management utility
+# This is an idrac management utility
+
+idracula generates instackenv.json file suitable for OpenStack installer based on
+TripleO like RDO-manager or OSP-directory.
+
+By design, idracula pick the first NIC with a 1GB link as the PXE interface. The hosts must be
+running before idracula is started, this because the NIC has to be active during the discovery.
+If you use auto-negotation, double check the NIC get the link negotiated as expected.
+
+Once a NIC has be found, idracula will switch its PXE boot parameter on.
 
 Right now, it only scans address ranges and spits out JSON for the dracs it finds.
 
 Example:
 
     $ ./idracula -u root -p 'password' -scan '192.168.128.1-192.168.128.254'
-
-yields (without logging output):
-
     {
       "nodes": [
         {

--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ type Nodes struct {
 }
 
 type scanInfo struct {
-	addr               net.IP
-	username, password string
+	addr                             net.IP
+	username, password, bootnic_name string
 }
 
 func waitForJob(client *wsman.Client, jobinfo *dom.Element) bool {
@@ -154,7 +154,7 @@ func getCPU(client *wsman.Client) string {
 	return strconv.Itoa(activeCores)
 }
 
-func getBootNic(client *wsman.Client, nics []*dom.Element) *dom.Element {
+func getBootNICCandidat(client *wsman.Client, nics []*dom.Element) []string {
 	fqdds := []string{}
 	for _, nic := range nics {
 		n := search.First(search.Tag("FQDD", "*"), nic.Children())
@@ -175,6 +175,17 @@ func getBootNic(client *wsman.Client, nics []*dom.Element) *dom.Element {
 			continue
 		}
 		fqdds = append(fqdds, fqdd)
+	}
+
+	return fqdds
+}
+
+func getBootNic(client *wsman.Client, nics []*dom.Element, bootnic_name string) *dom.Element {
+	fqdds := []string{}
+	if bootnic_name == "" {
+		fqdds = getBootNICCandidat(client, nics)
+	} else {
+		fqdds = append(fqdds, bootnic_name)
 	}
 	if len(fqdds) < 1 {
 		log.Printf("No integrated 1 GB nics!")
@@ -263,7 +274,7 @@ func getBootNic(client *wsman.Client, nics []*dom.Element) *dom.Element {
 	return result
 }
 
-func getMAC(client *wsman.Client) string {
+func getMAC(client *wsman.Client, bootnic_name string) string {
 	msg := client.Enumerate("http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_NICView")
 	msg.Selectors("InstanceID", "System.Embedded.1")
 	res, err := msg.Send()
@@ -272,7 +283,7 @@ func getMAC(client *wsman.Client) string {
 		return ""
 	}
 	bootnic := getBootNic(client,
-		search.All(search.Tag("DCIM_NICView", "*"), res.AllBodyElements()))
+		search.All(search.Tag("DCIM_NICView", "*"), res.AllBodyElements()), bootnic_name)
 	if bootnic == nil {
 		return ""
 	}
@@ -282,7 +293,7 @@ func getMAC(client *wsman.Client) string {
 			bootnic.Children()).Content))
 }
 
-func scanOne(in chan *scanInfo, out chan *NodeInfo, done chan int) {
+func scanOne(in chan *scanInfo, out chan *NodeInfo, done chan int, bootnic_name string) {
 	for {
 		c, ok := <-in
 		if !ok {
@@ -308,7 +319,7 @@ func scanOne(in chan *scanInfo, out chan *NodeInfo, done chan int) {
 				Cpu:        getCPU(client),
 				Disk:       getDisk(client),
 				Arch:       "x86_64",
-				Mac:        []string{getMAC(client)},
+				Mac:        []string{getMAC(client, bootnic_name)},
 			}
 			out <- node
 		}
@@ -316,7 +327,7 @@ func scanOne(in chan *scanInfo, out chan *NodeInfo, done chan int) {
 	done <- 1
 }
 
-func scan(addrs, username, password string) (res []*NodeInfo) {
+func scan(addrs, username, password string, bootnic_name string) (res []*NodeInfo) {
 	res = []*NodeInfo{}
 	workers := 100
 	scanChan := make(chan *scanInfo, workers)
@@ -324,7 +335,7 @@ func scan(addrs, username, password string) (res []*NodeInfo) {
 	doneChan := make(chan int)
 	// Make some workers
 	for i := 0; i < workers; i++ {
-		go scanOne(scanChan, resChan, doneChan)
+		go scanOne(scanChan, resChan, doneChan, bootnic_name)
 	}
 	// Produce a stream of work for them.
 	go func() {
@@ -336,7 +347,7 @@ func scan(addrs, username, password string) (res []*NodeInfo) {
 					log.Printf("Invalid IP address%s\n", addr)
 					continue
 				}
-				scanChan <- &scanInfo{addr: toScan, username: username, password: password}
+				scanChan <- &scanInfo{addr: toScan, username: username, password: password, bootnic_name: bootnic_name}
 			} else {
 				first := net.ParseIP(addrRange[0])
 				last := net.ParseIP(addrRange[1])
@@ -354,7 +365,7 @@ func scan(addrs, username, password string) (res []*NodeInfo) {
 					numLen := len(numBytes)
 					toScan := make([]byte, 16, 16)
 					copy(toScan[16-numLen:], numBytes)
-					scanChan <- &scanInfo{addr: toScan, username: username, password: password}
+					scanChan <- &scanInfo{addr: toScan, username: username, password: password, bootnic_name: bootnic_name}
 				}
 			}
 		}
@@ -378,9 +389,10 @@ func main() {
 	addrs := flag.String("scan", "", "Comma-seperated list of IP addresses to scan for iDRAC presence.\n      Ranges are allowed, and must be seperated by a hyphen.\n      IP4 and IP6 compatible, but only IP4 addresses tested.")
 	username := flag.String("u", "", "Username to try to log in as")
 	password := flag.String("p", "", "Password to try and use")
+	bootnic_name := flag.String("bootnic", "", "name of the NIC used for PXE")
 	flag.Parse()
 	if *addrs != "" {
-		nodes := &Nodes{Nodes: scan(*addrs, *username, *password)}
+		nodes := &Nodes{Nodes: scan(*addrs, *username, *password, *bootnic_name)}
 		res, err := json.MarshalIndent(nodes, "", "  ")
 		if err != nil {
 			log.Printf("Error formatting output: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -106,14 +106,13 @@ func getMemory(client *wsman.Client) string {
 }
 
 func getDisk(client *wsman.Client) string {
-	msg := client.Enumerate("http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_VirtualDiskView")
-	msg.Selectors("InstanceID", "System.Embedded.1")
+	msg := client.Enumerate("http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_PhysicalDiskView")
 	res, err := msg.Send()
 	if err != nil {
 		log.Printf("Error getting disks: %v\n", err)
 		return "-1"
 	}
-	vd := search.First(search.Tag("DCIM_VirtualDiskView", "*"), res.AllBodyElements())
+	vd := search.First(search.Tag("DCIM_PhysicalDiskView", "*"), res.AllBodyElements())
 	if vd == nil {
 		log.Printf("Error getting first disk information\n")
 		return "-1"


### PR DESCRIPTION
Disk key should give the size of the first disk in GB, not the number of hard
drive. During the nova boot, nova will compare this value with the
minimal mandatory size associated with the Glance image.

Without this patch, nova will always fail and returns the "no valid host was found"
message as soon as the size is greater than 1GB.

See: https://www.rdoproject.org/install/instack-faq/#What_is_the_NODES_JSON_file_format.3F
